### PR TITLE
Missing ArgumentNullException

### DIFF
--- a/GalaSoft.MvvmLight/GalaSoft.MvvmLight.Extras (PCL)/Ioc/SimpleIoc.cs
+++ b/GalaSoft.MvvmLight/GalaSoft.MvvmLight.Extras (PCL)/Ioc/SimpleIoc.cs
@@ -407,6 +407,12 @@ namespace GalaSoft.MvvmLight.Ioc
             bool createInstanceImmediately)
             where TClass : class
         {
+        
+            if (factory == null)
+            {
+                throw new ArgumentNullException("factory");
+            }
+            
             lock (_syncLock)
             {
                 var classType = typeof(TClass);


### PR DESCRIPTION
if factory == null  ArgumentNullException("factory")  is set on one of the register-methods but not the other one which seems odd to me so here's my proposal